### PR TITLE
fixed missing gio and GO 1.19 unsafe

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/diamondburned/gotk4/pkg v0.0.0-20220221063304-bbd86ac49f1b h1:k8jeCc8QOob32c95RcDGekTbdBMbHG0I7ZpkfUpC3PM=
-github.com/diamondburned/gotk4/pkg v0.0.0-20220221063304-bbd86ac49f1b/go.mod h1:dJ2gfR0gvBsGg4IteP8aMBq/U5Q9boDw0DP7kAjXTwM=
 github.com/diamondburned/gotk4/pkg v0.0.0-20220925114733-8c5529b9df15 h1:KjAeagrrvm20/EFCYiY41/NTnOlisFSVG4UnvwybTJ8=
 github.com/diamondburned/gotk4/pkg v0.0.0-20220925114733-8c5529b9df15/go.mod h1:pjOFSZWuNWiBwEqt+4/zfPr1JsNWY43h4B81ht3S3Ag=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=

--- a/gtk4/builder/main.go
+++ b/gtk4/builder/main.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 //go:embed main.ui

--- a/gtk4/cssdemo/main.go
+++ b/gtk4/cssdemo/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/diamondburned/gotk4/pkg/gdk/v4"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"github.com/diamondburned/gotk4/pkg/pango"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 //go:embed style.css

--- a/gtk4/drawingarea/main.go
+++ b/gtk4/drawingarea/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/diamondburned/gotk4/pkg/gdk/v4"
 	"github.com/diamondburned/gotk4/pkg/gdkpixbuf/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 const appID = "com.github.diamondburned.gotk4-examples.gtk4.drawingarea"

--- a/gtk4/drawingareamouseposition/main.go
+++ b/gtk4/drawingareamouseposition/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 const appID = "com.github.diamondburned.gotk4-examples.gtk4.drawingareamouseposition"

--- a/gtk4/goroutines/main.go
+++ b/gtk4/goroutines/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/diamondburned/gotk4/pkg/core/glib"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 func main() {

--- a/gtk4/hackernews/go.mod
+++ b/gtk4/hackernews/go.mod
@@ -10,4 +10,4 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
-require go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063 // indirect
+require go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect

--- a/gtk4/hackernews/go.sum
+++ b/gtk4/hackernews/go.sum
@@ -7,6 +7,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063 h1:1tk03FUNpulq2cuWpXZWj649rwJpk0d20rxWiopKRmc=
 go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
+go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/net v0.0.0-20220111093109-d55c255bac03 h1:0FB83qp0AzVJm+0wcIlauAjJ+tNdh7jLuacRYCIVv7s=
 golang.org/x/net v0.0.0-20220111093109-d55c255bac03/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=

--- a/gtk4/hackernews/main.go
+++ b/gtk4/hackernews/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/diamondburned/gotk4-examples/gtk4/hackernews/internal/gtkutil"
 	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 func main() {

--- a/gtk4/mouse/main.go
+++ b/gtk4/mouse/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/diamondburned/gotk4/pkg/cairo"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 const appID = "com.github.diamondburned.gotk4-examples.gtk4.mouse"

--- a/gtk4/simple/main.go
+++ b/gtk4/simple/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 func main() {

--- a/gtk4/treeview/treeview.go
+++ b/gtk4/treeview/treeview.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/diamondburned/gotk4/pkg/core/glib"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 )
 
 // ColumnType are IDs to access the tree view columns by.


### PR DESCRIPTION
Fixed GTK 4 examples to run without compilation errors.  Added missing gio package.

Upgraded version of referenced `go4.org/unsafe/assume-no-moving-gc` package so it allows GO 1.19 as a safe version for GC.

Run `go mod tidy` to cleanup.