### PR TITLE
Add Blueprint Example

### DIFF
--- a/gtk4/blueprint/README.md
+++ b/gtk4/blueprint/README.md
@@ -1,0 +1,9 @@
+### Run the Blueprint Example
+
+Run
+```sh
+go generate ./gtk4/blueprint/
+```
+before executing the usual `go run ./gtk4/blueprint/` command, to generate the `.ui` file from the blueprint.
+
+Make sure that you have [blueprint-compiler](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/) installed.

--- a/gtk4/blueprint/main.blp
+++ b/gtk4/blueprint/main.blp
@@ -1,0 +1,12 @@
+using Gtk 4.0;
+using Adw 1;
+
+Gtk.Window MyMainWindow {
+  default-width: 300;
+  default-height: 300;
+  title: _("gotk4 blueprint example");
+
+  Label MyLabel {
+    label: _("This window was generated from a Blueprint using go generate");
+  }
+}

--- a/gtk4/blueprint/main.go
+++ b/gtk4/blueprint/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+
+	_ "embed"
+
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
+	"github.com/diamondburned/gotk4/pkg/gtk/v4"
+)
+
+//go:generate blueprint-compiler compile ./main.blp --output ./main.ui
+//go:embed main.ui
+var uiXML string
+
+func main() {
+	app := gtk.NewApplication("com.github.diamondburned.gotk4-examples.gtk4.blueprint", gio.ApplicationFlagsNone)
+	app.ConnectActivate(func() { activate(app) })
+
+	if code := app.Run(os.Args); code > 0 {
+		os.Exit(code)
+	}
+}
+
+func activate(app *gtk.Application) {
+	//You can build UIs using Blueprint (https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/)
+	builder := gtk.NewBuilderFromString(uiXML, len(uiXML))
+
+	//MyMainWindow can be found inside the .blp file
+	window := builder.GetObject("MyMainWindow").Cast().(*gtk.Window)
+
+	app.AddWindow(window)
+	window.Show()
+}

--- a/gtk4/blueprint/main.ui
+++ b/gtk4/blueprint/main.ui
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <object class="GtkWindow" id="MyMainWindow">
+    <property name="default-width">300</property>
+    <property name="default-height">300</property>
+    <property name="title" translatable="true">gotk4 blueprint example</property>
+    <child>
+      <object class="GtkBox">
+        <property name="margin-start">30</property>
+        <property name="margin-end">30</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="true">Run </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="selectable">true</property>
+            <property name="label" translatable="true">go generate ./gtk4/blueprint</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="true"> to generate the UI file from the Blueprint and restart this app.</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
This PR adds sample instructions for using the experimental [blueprint-compiler](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/) in Go with gotk4.

Closes diamondburned/gotk4#75